### PR TITLE
the cloudfront is linked with the api gateway

### DIFF
--- a/sections/CloudFront/cloudfront.tf
+++ b/sections/CloudFront/cloudfront.tf
@@ -1,14 +1,28 @@
-//Defined CF Distribution 
-
 resource "aws_cloudfront_distribution" "main" {
   origin {
     domain_name = aws_s3_bucket.example.bucket_regional_domain_name
     origin_id   = "myS3Origin"
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.example.cloudfront_access_identity_path
+    }
+  }
+
+  origin {
+    domain_name = "${aws_api_gateway_rest_api.example.id}.execute-api.${var.region}.amazonaws.com"
+    origin_id   = "apiGatewayOrigin"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
   }
 
   enabled             = true
   is_ipv6_enabled     = true
-  comment             = "S3 CloudFront Distribution"
+  comment             = "S3 and API Gateway CloudFront Distribution"
   default_root_object = "index.html"
 
   default_cache_behavior {
@@ -30,6 +44,26 @@ resource "aws_cloudfront_distribution" "main" {
     max_ttl                = 86400
   }
 
+  ordered_cache_behavior {
+    path_pattern           = "/api/*"
+    target_origin_id       = "apiGatewayOrigin"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD", "OPTIONS", "POST"]
+    cached_methods         = ["GET", "HEAD"]
+
+    forwarded_values {
+      query_string = true
+
+      cookies {
+        forward = "all"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 0
+    max_ttl                = 0
+  }
+
   price_class = "PriceClass_All"
 
   restrictions {
@@ -41,4 +75,8 @@ resource "aws_cloudfront_distribution" "main" {
   viewer_certificate {
     cloudfront_default_certificate = true
   }
+}
+
+resource "aws_cloudfront_origin_access_identity" "example" {
+  comment = "Example OAI"
 }

--- a/sections/CloudFront/variables.tf
+++ b/sections/CloudFront/variables.tf
@@ -4,3 +4,7 @@ variable "cloudfront_price_class" {
   type        = string
   default     = "PriceClass_All"
 }
+
+variable "region" {
+  type = string
+}


### PR DESCRIPTION
By connecting API Gateway to CloudFront, one can leverage CloudFront's global edge network to enhance the performance, scalability, and security of the API. This configuration ensures that the API can manage high traffic volumes while delivering a fast and secure experience for end-users.